### PR TITLE
fix breakage on paths containing spaces

### DIFF
--- a/configure
+++ b/configure
@@ -90,8 +90,8 @@ create_environ() {
 : ${MANDIR:="${DATADIR}/man"}
 : ${LOCALSTATEDIR:="${SPREFIX}/var"}
 for A in `echo ${PATH} | sed -e 's,:, ,g'` ; do
-  [ -e $A/ginstall ] && : ${INSTALL:=$A/ginstall} && break
-  [ -e $A/install ] && : ${INSTALL:=$A/install} && break
+  [ -e "$A"/ginstall ] && : ${INSTALL:="$A"/ginstall} && break
+  [ -e "$A"/install ] && : ${INSTALL:="$A"/install} && break
 done
 : ${INSTALL_DIR:=${INSTALL} -d}
 : ${INSTALL_DATA:=${INSTALL} -m 644}

--- a/src/acr-sh
+++ b/src/acr-sh
@@ -1476,8 +1476,8 @@ create_environ() {
 : ${S}{MANDIR:="${S}{DATADIR}/man"}
 : ${S}{LOCALSTATEDIR:="${S}{SPREFIX}/var"}
 for A in \`echo ${S}{PATH} | sed -e 's,:, ,g'\` ; do
-  [ -e ${S}A/ginstall ] && : ${S}{INSTALL:=${S}A/ginstall} && break
-  [ -e ${S}A/install ] && : ${S}{INSTALL:=${S}A/install} && break
+  [ -e "${S}A"/ginstall ] && : ${S}{INSTALL:="${S}A"/ginstall} && break
+  [ -e "${S}A"/install ] && : ${S}{INSTALL:="${S}A"/install} && break
 done
 : ${S}{INSTALL_DIR:=${S}{INSTALL} -d}
 : ${S}{INSTALL_DATA:=${S}{INSTALL} -m 644}


### PR DESCRIPTION
This fixes errors on macOS like the following.

```
…
./configure: line 95: [: too many arguments
./configure: line 96: [: too many arguments
./configure: line 95: [: too many arguments
./configure: line 96: [: too many arguments
./configure: line 95: [: /Applications/Photo: binary operator expected
./configure: line 96: [: /Applications/Photo: binary operator expected
./configure: line 95: [: /Applications/QuickTime: binary operator expected
./configure: line 96: [: /Applications/QuickTime: binary operator expected
…
```